### PR TITLE
Improved the PKGBUILD according to our standard

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: echo -n 'bWF0dEBnZXRjcnlzdC5hbA==' | base64 --decode
+# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA==' | base64 -d
 
-pkgname=jade_tui
+pkgname=jade-tui
 pkgver=1.0.0
-pkgrel=1
-pkgdesc="TUI for installing the system with jade"
+pkgrel=2
+pkgdesc="Tui frontend for the jade installer"
 license=('GPL3')
 arch=('any')
-url="https://github.com/crystal-linux/jade-tui"
-source=("git+${url}.git")
+url="https://github.com/crystal-linux/${pkgname}"
 depends=('jade' 'gum' 'openssl')
-md5sums=('f8bfed0ea3f1b5e85138b0c8b4770e48'
-         'cba37f460dcf5f678043df39d6378c35')
+source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('faf95c456e5d10c92372ccc007cbb25f4f65b43d7016e99388cffdc8d9abf982')
 
 package() {
-    install -D -m 755 ${srcdir}/jade-tui/jade-tui ${pkgdir}/usr/bin/.
-    install -D -m 700 ${srcdir}/jade-tui/locales ${pkgdir}/usr/share/jade-tui/.
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    install -Dm 755 "${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+    install -Dm 644 locales "${pkgdir}/usr/share/${pkgname}/locales"
 }


### PR DESCRIPTION
Hi,

A round of improvements for the `jade-tui`'s PKGBUILD:

- Changed the `pkgname` from `jade_tui` to `jade-tui` to get compliant with the name of the software and upstream repo.
- Modified the `pkgdesc` to match the upstream repo description.
- Switched from `git` sources to release's archive. Added the integrity check accordingly.
- Switched the integrity check from `md5` to `sha256`.
- Populated the usage of `${pkgname}` instead of `jade-tui`.
- Slight style changes to the `package ()` function.
- Modified the permissions of the `locales` file from `700` to `644`. AFAIK, it doesn't have to be executable and ca be safely readable by anyone so it should use a classic permissions value IMO.

What do you think?
